### PR TITLE
Corrected license identifier in library.properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,80 @@
 # ros2arduino
+Arduino library for communicating with ROS2(DDS)
+
+<br>
+
+## Version-specific dependencies
+
+|ros2arduino|ROS2|Micro-XRCE-DDS Agent|
+|:-:|:-:|:-:|
+|0.0.1|[Crystal Clemmys](https://github.com/ros2/ros2/releases/tag/prerelease-crystal-2018-12-08)|[1.0.1](https://github.com/eProsima/Micro-XRCE-DDS-Agent/releases/tag/v1.0.1)|
+||||
+
+<br>
+
+## Restrictions
+
+#### Available boards (What we've tested on our own)
+Based on the normal behavior of publisher and subscriber.
+
+ - [OpenCR](http://emanual.robotis.com/docs/en/parts/controller/opencr10/)
+ - [OpenCM9.04](http://emanual.robotis.com/docs/en/parts/controller/opencm904/)
+ - Arduino MKR ZERO
+ - Arduino DUE
+
+#### Communication
+ ||Implemented|Note|
+ |:-:|:-:|:-:|
+ |Serial|YES|only Serial (NOT Serial1,2,3..etc)|
+ |UDP|NO||
+ |TCP|NO||
+
+<br>
+
+## Getting Start
+
+#### Dependancy Installation
+ - [ROS2](https://index.ros.org/doc/ros2/Installation/)
+ - XRCE-DDS Agent
+	 - [Micro-XRCE-DDS Agent](https://micro-xrce-dds.readthedocs.io/en/latest/installation.html#installing-the-agent-stand-alone) for FastRTPS
+
+#### Upload Arduino sketch
+ - [File] - [Examples] - [ros2arduino] - [publisher]
+ - [Sketch] - [Upload]
+ 
+ 
+#### Excute XRCE-DDS Agent
+```bash
+$ MicroXRCEAgent serial /dev/ttyACM0
+```
+
+#### Check topic on ROS2
+```bash
+$ ros2 topic echo /arduino_chatter
+```
+ 
+ <br>
+ 
+## Development Note
+
+#### Lastest release
+ - **Feature**
+    - Only one node avaliable
+    - Publisher
+    - Subscriber
+ - **Communication**
+    - Serial (Only Serial instance avaliable)
+
+#### Plan
+ - **Feature**
+    - ROS2 service
+ - **Communication**
+    - expand Serial port (To use other Serial instance)
+    - Ethernet Shield (UDP, TCP)
+    - ESP32 (UDP, TCP)
+ - **Enhancements**
+    - Memory allocation / Management
+    - Reduce memory usages
+    - Reusable API interfaces
+    - Reasonable SW structure
+    

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $ ros2 topic echo /arduino_chatter
 
 #### Lastest release
  - **Feature**
-    - Only one node avaliable
+    - Only one node available
     - Publisher
     - Subscriber
  - **Communication**

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Arduino library for communicating with ROS2(DDS)
 
 |ros2arduino|ROS2|Micro-XRCE-DDS Agent|
 |:-:|:-:|:-:|
-|0.0.1|[Crystal Clemmys](https://github.com/ros2/ros2/releases/tag/prerelease-crystal-2018-12-08)|[1.0.1](https://github.com/eProsima/Micro-XRCE-DDS-Agent/releases/tag/v1.0.1)|
+|0.0.1|[Crystal Clemmys](https://github.com/ros2/ros2/releases/tag/release-crystal-20181214)|[1.0.1](https://github.com/eProsima/Micro-XRCE-DDS-Agent/releases/tag/v1.0.1)|
 ||||
 
 <br>

--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=ros2arduino
 version=0.0.1
 author=ROBOTIS
-license=Apache 2.0
+license=Apache-2.0
 maintainer=Kei(kkw@robotis.com)
 sentence=ROS2 Library for Arduino
 paragraph=This library helps the Arduino board communicate with the ROS2 using XRCE-DDS.


### PR DESCRIPTION
It should be a valid SPDX License Identifier:
https://spdx.org/licenses/
