### PR TITLE
Fix formatting of keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,24 +6,24 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-ros2::Node  KEYWORD1    
-ros2::CallbackFunc    KEYWORD1
+ros2::Node	KEYWORD1
+ros2::CallbackFunc	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-ros2::Node  KEYWORD2
-ros2::Publisher KEYWORD2
-ros2::Subscriber    KEYWORD2
+ros2::Node	KEYWORD2
+ros2::Publisher	KEYWORD2
+ros2::Subscriber	KEYWORD2
 
-ros2::init  KEYWORD2
-ros2::spin  KEYWORD2
+ros2::init	KEYWORD2
+ros2::spin	KEYWORD2
 
-createPublisher KEYWORD2
-createSubscriber    KEYWORD2
-createWallFreq  KEYWORD2
-createWallTimer  KEYWORD2
+createPublisher	KEYWORD2
+createSubscriber	KEYWORD2
+createWallFreq	KEYWORD2
+createWallTimer	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/keywords.txt
+++ b/keywords.txt
@@ -8,9 +8,9 @@
 
 Node	KEYWORD1
 Publisher KEYWORD1
-Subscriber  KEYWORD1
+Subscriber	KEYWORD1
 
-CallbackFunc  KEYWORD1
+CallbackFunc	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -23,6 +23,10 @@ createPublisher	KEYWORD2
 createSubscriber	KEYWORD2
 createWallFreq	KEYWORD2
 createWallTimer	KEYWORD2
+
+#######################################
+# Structures (KEYWORD3)
+#######################################
 
 #######################################
 # Constants (LITERAL1)

--- a/keywords.txt
+++ b/keywords.txt
@@ -7,15 +7,14 @@
 #######################################
 
 Node	KEYWORD1
-CallbackFunc	KEYWORD1
+Publisher KEYWORD1
+Subscriber  KEYWORD1
+
+CallbackFunc  KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-
-Node	KEYWORD2
-Publisher	KEYWORD2
-Subscriber	KEYWORD2
 
 init	KEYWORD2
 spin	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -6,19 +6,19 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-ros2::Node	KEYWORD1
-ros2::CallbackFunc	KEYWORD1
+Node	KEYWORD1
+CallbackFunc	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-ros2::Node	KEYWORD2
-ros2::Publisher	KEYWORD2
-ros2::Subscriber	KEYWORD2
+Node	KEYWORD2
+Publisher	KEYWORD2
+Subscriber	KEYWORD2
 
-ros2::init	KEYWORD2
-ros2::spin	KEYWORD2
+init	KEYWORD2
+spin	KEYWORD2
 
 createPublisher	KEYWORD2
 createSubscriber	KEYWORD2


### PR DESCRIPTION
- Use correct field separator
- Correct formatting of keyword definitions 