### PR TITLE
Change HZ from uint32_t to float

### DIFF
--- a/src/ros2/ros2.cpp
+++ b/src/ros2/ros2.cpp
@@ -202,7 +202,7 @@ void ros2::Node::createWallTimer(uint32_t msec, CallbackFunc callback, void* cal
   pub->callback_arg = callback_arg;
 }
 
-void ros2::Node::createWallFreq(uint32_t hz, CallbackFunc callback, void* callback_arg, PublisherHandle* pub)
+void ros2::Node::createWallFreq(float hz, CallbackFunc callback, void* callback_arg, PublisherHandle* pub)
 {
   uint32_t msec;
   if(hz > 1000)

--- a/src/ros2/ros2.hpp
+++ b/src/ros2/ros2.hpp
@@ -29,7 +29,7 @@ class Node
 
     void recreate(const char* node_name = "ros2_xrcedds_participant",unsigned int client_key=0xAABBCCDD);
     void createWallTimer(uint32_t msec, CallbackFunc callback, void* callback_arg, PublisherHandle* pub);
-    void createWallFreq(uint32_t hz, CallbackFunc callback, void* callback_arg, PublisherHandle* pub);
+    void createWallFreq(float hz, CallbackFunc callback, void* callback_arg, PublisherHandle* pub);
     void runPubCallback();
     void runSubCallback(uint16_t reader_id, void* serialized_msg);
 


### PR DESCRIPTION
Suggest Change ros2.cpp and ros2.hpp>>void ros2::Node::createWallFreq(float hz, CallbackFunc callback, void* callback_arg, PublisherHandle* pub),to allow Freq below 1.
Signed-off-by: yottayuan <yuantingwork@163.com>