### PR TITLE
Suggest to source setup.bash before build Micro-XRCE-DDS-Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ For the Micro-XRCE-DDS Agent, please install it using following commands.
 $ git clone https://github.com/eProsima/Micro-XRCE-DDS-Agent.git
 $ cd Micro-XRCE-DDS-Agent && git checkout v1.1.0
 $ mkdir build && cd build
+$ /opt/ros/dashing/setup.bash # to share libraries with ros2
 $ cmake ..
 $ make
 $ sudo make install


### PR DESCRIPTION
Thank you for sharing a useful project.

I failed to run Micro-XRCE-DDS Agent with ros2arduino because causing the following error.

```
MicroXRCEAgent serial --dev /dev/ttyUSB0 -b 115200
Enter 'q' for exit
[1579357225.053981] info     | SerialServerLinux.cpp | init                     | running...             | fd: 3
[1579357228.139310] info     | Root.cpp           | create_client            | create                 | client_key: 0xAABBCCDD, session_id: 0x81
[1579357228.139433] info     | SerialServerBase.cpp | on_create_client         | session established    | client_key: 0xAABBCCDD, address: 0
terminate called after throwing an instance of 'std::bad_alloc'
  what():  std::bad_alloc
```

I found difference that dependency of library changes by running setup.bash of ROS2(by referencing https://qiita.com/nomumu/items/db01bc9e39bf1fb116d5 ).

Before run setup.bash.
```
$ ldd `which MicroXRCEAgent`
	linux-vdso.so.1 (0x00007ffc157c6000)
	libmicroxrcedds_agent.so.1.1 => /usr/local/lib/libmicroxrcedds_agent.so.1.1 (0x00007f61cd8c4000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f61cd6a5000)
	libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f61cd31c000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f61cd104000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f61ccd13000)
	libfastrtps.so.1 => /usr/local/lib/libfastrtps.so.1 (0x00007f61cc5bf000)
	libmicroxrcedds_client.so.1.1 => /usr/local/lib/libmicroxrcedds_client.so.1.1 (0x00007f61cc3a8000)
	libmicrocdr.so.1.1 => /usr/local/lib/libmicrocdr.so.1.1 (0x00007f61cc19c000)
	libfastcdr.so.1 => /usr/local/lib/libfastcdr.so.1 (0x00007f61cbf89000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f61cde7a000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f61cbbeb000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f61cb9e7000)
	libssl.so.1.1 => /usr/lib/x86_64-linux-gnu/libssl.so.1.1 (0x00007f61cb75a000)
	libcrypto.so.1.1 => /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 (0x00007f61cb28f000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f61cb087000)
```

After run setup.bash.
```
$ source /opt/ros/dashing/setup.bash
$ ldd `which MicroXRCEAgent`
	linux-vdso.so.1 (0x00007ffff77de000)
	libmicroxrcedds_agent.so.1.1 => /usr/local/lib/libmicroxrcedds_agent.so.1.1 (0x00007f0fa403d000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f0fa3e1e000)
	libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f0fa3a95000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f0fa387d000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f0fa348c000)
	libfastrtps.so.1 => /opt/ros/dashing/lib/libfastrtps.so.1 (0x00007f0fa2cf6000)
	libmicroxrcedds_client.so.1.1 => /usr/local/lib/libmicroxrcedds_client.so.1.1 (0x00007f0fa2adf000)
	libmicrocdr.so.1.1 => /usr/local/lib/libmicrocdr.so.1.1 (0x00007f0fa28d3000)
	libfastcdr.so.1 => /opt/ros/dashing/lib/libfastcdr.so.1 (0x00007f0fa26c1000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f0fa45f3000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f0fa2323000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f0fa211f000)
	libtinyxml2.so.6 => /usr/lib/x86_64-linux-gnu/libtinyxml2.so.6 (0x00007f0fa1f0b000)
	libssl.so.1.1 => /usr/lib/x86_64-linux-gnu/libssl.so.1.1 (0x00007f0fa1c7e000)
	libcrypto.so.1.1 => /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 (0x00007f0fa17b3000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f0fa15ab000)
```

I found that I can avoid the error by the following combinations.

MicroXRCEAgent build env | MicroXRCEAgent run env
---- | ----
With sourcing setup.bash | With sourcing setup.bash
Without sourcing setup.bash | Without sourcing setup.bash
Without sourcing setup.bash | With sourcing setup.bash and run with adding `LD_PRELOAD="/usr/local/lib/libfastrtps.so.1` as prefix of command. Ex: ```LD_PRELOAD="/usr/local/lib/libfastrtps.so.1" MicroXRCEAgent serial --dev /dev/ttyUSB0 -b 115200```

I think it's better that the dependencies of ros2 and MicroXRCEAgent are same.
So how about to add a command to source setup.bash of ros2 before making MicroXRCEAgent.

Thank you.